### PR TITLE
[feat/#72-add-property-image] 매물 리스트 이미지 추가

### DIFF
--- a/src/main/java/com/example/Dingle/property/dto/DetailPropertyDTO.java
+++ b/src/main/java/com/example/Dingle/property/dto/DetailPropertyDTO.java
@@ -20,6 +20,7 @@ public class DetailPropertyDTO {
     private DealInfo deal;
     private List<Integer> conditions;
     private PropertyInfo propertyInfo;
+    private PropertyImages images;
     private Option option;
     private Facility facility;
     private RealtorInfo realtorInfo;
@@ -44,6 +45,14 @@ public class DetailPropertyDTO {
         private boolean liked;
         private double latitude;
         private double longitude;
+    }
+
+    @Getter
+    @Builder
+    @AllArgsConstructor
+    public static class PropertyImages {
+        private String floorImageUrl;
+        private List<String> propertyImageUrls;
     }
 
     @Getter

--- a/src/main/java/com/example/Dingle/property/dto/MainPropertyResponseDTO.java
+++ b/src/main/java/com/example/Dingle/property/dto/MainPropertyResponseDTO.java
@@ -25,6 +25,7 @@ public class MainPropertyResponseDTO {
     @AllArgsConstructor
     public static class PropertyItem {
         private Long propertyId;
+        private String imageUrl;
         private PropertyType propertyType;
         private String apartmentName;
         private Double exclusiveArea;

--- a/src/main/java/com/example/Dingle/property/repository/PropertyImageRepository.java
+++ b/src/main/java/com/example/Dingle/property/repository/PropertyImageRepository.java
@@ -1,0 +1,15 @@
+package com.example.Dingle.property.repository;
+
+import com.example.Dingle.property.entity.PropertyImage;
+import com.example.Dingle.property.type.ImageType;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface PropertyImageRepository extends JpaRepository<PropertyImage, Long> {
+    List<PropertyImage> findAllByProperty_IdInAndImageTypeOrderByProperty_IdAsc(List<Long> propertyIds, ImageType imageType);
+    List<PropertyImage> findAllByProperty_IdAndImageType(Long propertyId, ImageType imageType);
+    PropertyImage findByProperty_IdAndImageType(Long propertyId, ImageType imageType);
+}

--- a/src/main/java/com/example/Dingle/property/service/DetailPropertyService.java
+++ b/src/main/java/com/example/Dingle/property/service/DetailPropertyService.java
@@ -45,7 +45,7 @@ public class DetailPropertyService {
                 .orElseThrow(() -> new BusinessException(BusinessErrorMessage.PROPERTY_NOT_EXISTS));
 
         PropertyImage floorImage = propertyImageRepository.findByProperty_IdAndImageType(propertyId, ImageType.FLOOR_IMAGE);
-        String floorImageUrl = floorImage.getImageUrl();
+        String floorImageUrl = (floorImage != null) ? floorImage.getImageUrl() : null;
 
         List<PropertyImage> propertyImages = propertyImageRepository.findAllByProperty_IdAndImageType(propertyId, ImageType.PROPERTY);
         List<String> propertyImageUrls = propertyImages.stream()

--- a/src/main/java/com/example/Dingle/property/service/DetailPropertyService.java
+++ b/src/main/java/com/example/Dingle/property/service/DetailPropertyService.java
@@ -2,13 +2,10 @@ package com.example.Dingle.property.service;
 
 import com.example.Dingle.global.exception.BusinessException;
 import com.example.Dingle.global.message.BusinessErrorMessage;
-import com.example.Dingle.onboarding.repository.PreferredConditionRepository;
 import com.example.Dingle.property.dto.DetailPropertyDTO;
-import com.example.Dingle.property.entity.Property;
-import com.example.Dingle.property.entity.PropertyFacility;
-import com.example.Dingle.property.entity.PropertyOption;
-import com.example.Dingle.property.entity.PropertyScore;
+import com.example.Dingle.property.entity.*;
 import com.example.Dingle.property.repository.*;
+import com.example.Dingle.property.type.ImageType;
 import com.example.Dingle.realtor.entity.Realtor;
 import com.example.Dingle.user.entity.User;
 import com.example.Dingle.user.repository.SavedPropertyRepository;
@@ -27,14 +24,16 @@ public class DetailPropertyService {
     private final PropertyFacilityRepository propertyFacilityRepository;
     private final PropertyScoreRepository propertyScoreRepository;
     private final SavedPropertyRepository savedPropertyRepository;
+    private final PropertyImageRepository propertyImageRepository;
 
-    public DetailPropertyService(UserRepository userRepository, PropertyRepository propertyRepository, PropertyOptionRepository propertyOptionRepository, PropertyFacilityRepository propertyFacilityRepository, PropertyScoreRepository propertyScoreRepository, SavedPropertyRepository savedPropertyRepository) {
+    public DetailPropertyService(UserRepository userRepository, PropertyRepository propertyRepository, PropertyOptionRepository propertyOptionRepository, PropertyFacilityRepository propertyFacilityRepository, PropertyScoreRepository propertyScoreRepository, SavedPropertyRepository savedPropertyRepository, PropertyImageRepository propertyImageRepository) {
         this.userRepository = userRepository;
         this.propertyRepository = propertyRepository;
         this.propertyOptionRepository = propertyOptionRepository;
         this.propertyFacilityRepository = propertyFacilityRepository;
         this.propertyScoreRepository = propertyScoreRepository;
         this.savedPropertyRepository = savedPropertyRepository;
+        this.propertyImageRepository = propertyImageRepository;
     }
 
     public DetailPropertyDTO getDetailProperty(String userId, Long propertyId) {
@@ -44,6 +43,14 @@ public class DetailPropertyService {
 
         Property property = propertyRepository.findById(propertyId)
                 .orElseThrow(() -> new BusinessException(BusinessErrorMessage.PROPERTY_NOT_EXISTS));
+
+        PropertyImage floorImage = propertyImageRepository.findByProperty_IdAndImageType(propertyId, ImageType.FLOOR_IMAGE);
+        String floorImageUrl = floorImage.getImageUrl();
+
+        List<PropertyImage> propertyImages = propertyImageRepository.findAllByProperty_IdAndImageType(propertyId, ImageType.PROPERTY);
+        List<String> propertyImageUrls = propertyImages.stream()
+                .map(PropertyImage::getImageUrl)
+                .toList();
 
         PropertyScore propertyScores = propertyScoreRepository.findAllByPropertyId(propertyId);
         Map<Integer, Integer> scoreMap = Map.of(
@@ -106,6 +113,10 @@ public class DetailPropertyService {
                         .liked(isLiked)
                         .longitude(property.getLongitude())
                         .latitude(property.getLatitude())
+                        .build())
+                .images(DetailPropertyDTO.PropertyImages.builder()
+                        .floorImageUrl(floorImageUrl)
+                        .propertyImageUrls(propertyImageUrls)
                         .build())
                 .option(DetailPropertyDTO.Option.builder()
                         .optionCount(optionList.size())

--- a/src/main/java/com/example/Dingle/property/service/MainPropertyService.java
+++ b/src/main/java/com/example/Dingle/property/service/MainPropertyService.java
@@ -149,7 +149,7 @@ public class MainPropertyService {
         Map<Long, String> mainImage = new HashMap<>();
         for(PropertyImage image : images) {
             Long id = image.getProperty().getId();
-            mainImage.put(id, image.getImageUrl());
+            mainImage.putIfAbsent(id, image.getImageUrl());
         }
 
         List<MainPropertyResponseDTO.PropertyItem> items = pagedList.stream()


### PR DESCRIPTION
## 🔍️ 이 PR을 통해 해결하려는 문제가 무엇인가요?
- closed #72 
## ✨ 이 PR에서 핵심적으로 변경된 사항은 무엇일까요?
> 문제를 해결하면서 주요하게 변경된 사항들을 적어 주세요
- 매물 리스트의 대표 이미지를 출력합니다.
- 매물 상세 조회 시 매물 이미지와 도면 이미지를 출력합니다. 

## 🙏 Reviewer 분들이 이런 부분을 신경써서 봐 주시면 좋겠어요
> 개발 과정에서 다른 분들의 의견은 어떠한지 궁금했거나 크로스 체크가 필요하다고 느껴진 코드가 있다면 남겨주세요

## 🩺 이 PR에서 테스트 혹은 검증이 필요한 부분이 있을까요?
> 테스트가 필요한 항목이나 테스트 코드가 추가되었다면 함께 적어주세요

### 📌 PR 진행 시 이러한 점들을 참고해 주세요
* Reviewer 분들은 코드 리뷰 시 좋은 코드의 방향을 제시하되, 코드 수정을 강제하지 말아 주세요.
* Reviewer 분들은 좋은 코드를 발견한 경우, 칭찬과 격려를 아끼지 말아 주세요.
* Comment 작성 시 Prefix로 P1, P2, P3 를 적어 주시면 Assignee가 보다 명확하게 Comment에 대해 대응할 수 있어요
    * P1 : 꼭 반영해 주세요 - 이슈가 발생하거나 취약점이 발견되는 케이스 등
    * P2 : 반영을 적극적으로 고려해 주시면 좋을 것 같아요
    * P3 : 이런 방법도 있을 것 같아요~ 등의 사소한 의견입니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 부동산 상세 페이지에서 층 이미지와 다중 부동산 이미지 확인 가능
  * 부동산 목록 항목에 대표 이미지(imageUrl) 표시로 시각적 정보 제공 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->